### PR TITLE
Persist configurations with models

### DIFF
--- a/src/app/features/agents/agent-preview/agent-preview.ts
+++ b/src/app/features/agents/agent-preview/agent-preview.ts
@@ -31,16 +31,34 @@ export class AgentPreview {
     this.route.params.subscribe(params => {
       const modelId = params['id'];
       this.api.get(`models/${modelId}`).subscribe((data: any) => {
-        this.model = { ...data, mapper: data.mapper ?? {}, randomizers: data.randomizers ?? [] };
+        this.model = {
+          ...data,
+          mapper: data.mapper ?? {},
+          randomizers: data.randomizers ?? [],
+          configuration: data.configuration ?? { attributes: [], formats: [], randomizers: [] }
+        };
       });
     });
   }
 
   public saveModel() {
-    this.api.put(`models/${this.model._id}`, this.model).subscribe((data: any) => {
-      this.model = { ...data, mapper: data.mapper ?? {}, randomizers: data.randomizers ?? [] };
-      this.api.get('models/').subscribe((models: any) => {
-        this.app.models = models;
+    const config = this.model.configuration;
+    const config$ = config?._id
+      ? this.api.put(`models/configurations/${config._id}`, config)
+      : this.api.post('models/configurations/', config);
+
+    config$.subscribe((savedCfg: any) => {
+      this.model.configuration = savedCfg;
+      this.api.put(`models/${this.model._id}`, this.model).subscribe((data: any) => {
+        this.model = {
+          ...data,
+          mapper: data.mapper ?? {},
+          randomizers: data.randomizers ?? [],
+          configuration: data.configuration ?? savedCfg
+        };
+        this.api.get('models/').subscribe((models: any) => {
+          this.app.models = models;
+        });
       });
     });
   }

--- a/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/attributes-form.html
+++ b/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/attributes-form.html
@@ -38,7 +38,7 @@
                 </p-select>
                 <p-button class="attribute-rule-param-column" icon="pi pi-eye" severity="secondary" text size="small"
                     pTooltip="Voir la configuration" appendTo="body"
-                    (click)="openConfigurationDialog(attribute.value.parameters.object_id)"></p-button>
+                    (click)="openConfigurationDialog(attribute)"></p-button>
                 }
                 }
             </div>

--- a/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/attributes-form.ts
+++ b/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/attributes-form.ts
@@ -11,7 +11,6 @@ import { AttributeRequirementDialog } from './attribute-requirement-dialog/attri
 import { ApiService } from '../../../../../../core/services/api.service';
 import { DataDialog } from './data-dialog/data-dialog';
 import { ConfigurationDialog } from './configuration-dialog/configuration-dialog';
-import { ConfigurationForm } from '../configuration-form';
 
 @Component({
   selector: 'app-attributes-form',
@@ -116,8 +115,9 @@ export class AttributesForm {
     });
   }
 
-  public openConfigurationDialog(object_id: string) {
-    this.ref = this.dialogService.open(ConfigurationForm, {
+  public openConfigurationDialog(attribute: any) {
+    const object_id = attribute.value.parameters.object_id;
+    this.ref = this.dialogService.open(ConfigurationDialog, {
       header: "Configuration",
       width: '70vw',
       contentStyle: { overflow: 'auto' },
@@ -127,8 +127,14 @@ export class AttributesForm {
     });
 
     this.ref.onClose.subscribe((data: any) => {
-      if (data) {
-        // Handle the data returned from the dialog
+      if (data?._id) {
+        attribute.value.parameters.object_id = data._id;
+        const existing = this.configurationOptions.find((o: any) => o.value === data._id);
+        if (existing) {
+          existing.label = data.name;
+        } else {
+          this.configurationOptions = [...this.configurationOptions, { label: data.name, value: data._id }];
+        }
       }
     });
   }

--- a/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/configuration-dialog/configuration-dialog.ts
+++ b/src/app/features/agents/agent-preview/model-form/configuration-form/attributes-form/configuration-dialog/configuration-dialog.ts
@@ -13,13 +13,13 @@ import { ConfigurationForm } from "../../configuration-form";
     <div *ngIf="loaded; else loadingTpl">
       <div class="form__wrapper">
         <div class="group-inputs">
-          <app-configuration-form />
+          <app-configuration-form [configuration]="configuration" />
         </div>
       </div>
 
       <div class="dialog-footer">
         <p-button size="small" variant="text" severity="secondary" label="Annuler" (click)="ref.close(false)"></p-button>
-        <p-button size="small" severity="secondary" label="Confirmer" (click)="ref.close(true)"></p-button>
+        <p-button size="small" severity="secondary" label="Confirmer" (click)="onConfirm()"></p-button>
       </div>
     </div>
 
@@ -41,6 +41,7 @@ import { ConfigurationForm } from "../../configuration-form";
 })
 export class ConfigurationDialog implements OnInit {
 
+  public configuration: any;
   public loaded = false;
 
   private api: ApiService = inject(ApiService);
@@ -48,5 +49,30 @@ export class ConfigurationDialog implements OnInit {
   constructor(public ref: DynamicDialogRef, public cfg: DynamicDialogConfig) { }
 
   ngOnInit(): void {
+    const id = this.cfg?.data?.object_id;
+    if (!id) {
+      this.configuration = { name: '', description: '', attributes: [], formats: [], randomizers: [] };
+      this.loaded = true;
+      return;
+    }
+
+    this.api.get(`models/configurations/${id}`).subscribe({
+      next: (res: any) => {
+        this.configuration = res ?? { name: '', description: '', attributes: [], formats: [], randomizers: [] };
+        this.loaded = true;
+      },
+      error: () => {
+        this.configuration = { name: '', description: '', attributes: [], formats: [], randomizers: [] };
+        this.loaded = true;
+      }
+    });
+  }
+
+  public onConfirm(): void {
+    const req = this.configuration?._id
+      ? this.api.put(`models/configurations/${this.configuration._id}`, this.configuration)
+      : this.api.post('models/configurations/', this.configuration);
+
+    req.subscribe((res: any) => this.ref.close(res));
   }
 }

--- a/src/app/features/agents/agent-preview/model-form/model-form.html
+++ b/src/app/features/agents/agent-preview/model-form/model-form.html
@@ -22,6 +22,6 @@
             Configuration
         </p-divider>
 
-        <app-configuration-form />
+        <app-configuration-form [configuration]="model.configuration" />
     </div>
 </div>


### PR DESCRIPTION
## Summary
- save model configuration before persisting model
- bind model configuration to configuration form
- allow configuration dialog to save via API and update parent attribute

## Testing
- `npm run lint` *(fails: TypeScript lint errors throughout repository)*

------
https://chatgpt.com/codex/tasks/task_e_68beb09517f8832a90ac1603cc074b9c